### PR TITLE
Changed "LLM" to "Language" in AILuminate Naming and Versioning.md

### DIFF
--- a/AILuminate Naming and Versioning.md
+++ b/AILuminate Naming and Versioning.md
@@ -32,7 +32,7 @@ Audiences have their own goals for why they’re looking at the name of a benchm
 | :---- | :---- | :---- |
 | *Language* | French | Simplified Chinese |
 | *Region* | \[Belgium \| Canada \|...\] | \[Shanghai \| Taiwan \| …\] |
-| *SUT Type* | LLM | Multimodal |
+| *SUT Type* | Language | Multimodal |
 | *SUT Specialization* | \[Interactive Chat \| instruction generation \| …\] | \[Image-to-text \| Speech-to-text \| …\] |
 | *Domain* | General Purpose | \[Financial \| Medical \| …\] |
 | *Release type* | General Availability | \[Release Candidate \| Test \| …\] |


### PR DESCRIPTION
A proposed change from "LLM" to "Language" in naming AILuminate. "LLM" implies a specific kind of SUT, while there may be many different kinds of language-based systems that are not LLM-based. LLM doesn't parse well by itself "AILuminate Language" feels like it explains the tool better, especially in a non-technical discussion.